### PR TITLE
Use Xwt.IconSize instead of Gtk.IconSize

### DIFF
--- a/src/MonoDevelop.LogMonitor/MonoDevelop.LogMonitor/LogMonitorLogger.cs
+++ b/src/MonoDevelop.LogMonitor/MonoDevelop.LogMonitor/LogMonitorLogger.cs
@@ -79,7 +79,7 @@ namespace MonoDevelop.LogMonitor
 		{
 			Runtime.RunInMainThread (() => {
 				if (statusBarIcon == null) {
-					var icon = ImageService.GetIcon ("md-text-file-icon", Gtk.IconSize.Menu);
+					var icon = ImageService.GetIcon ("md-text-file-icon", Xwt.IconSize.Small);
 					statusBarIcon = IdeApp.Workbench.StatusBar.ShowStatusIcon (icon);
 					statusBarIcon.Clicked += StatusBarIconClicked;
 				}


### PR DESCRIPTION
Recent changes in the Visual Studio for Mac ImageService, drops Gtk.IconSize for Xwt.IconSize.